### PR TITLE
Added CNAME option to deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,5 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          cname: docs.edgebox.io
           publish_dir: ./site


### PR DESCRIPTION
This adds the necessary config for the docs page to be served via the custom subdomain [docs.edgebox.io](https://docs.edgebox.io)

Note:

- This info was also added in this repo settings (so GitHub validates the CNAME config)
- The CNAME `docs -> edgebox-iot.github.io` was added to the edgebox.io records